### PR TITLE
add: agregar filtro para quejas eliminadas en servicio

### DIFF
--- a/middleware/recaptcha.js
+++ b/middleware/recaptcha.js
@@ -1,7 +1,7 @@
 
 const verifyRecaptcha = async (token) => {
 
-    if (process.env.NODE_ENV === 'development ') {
+    if (process.env.NODE_ENV === 'development') {
         return true;
     }
 

--- a/migrations/20250908161921-create-entities.js
+++ b/migrations/20250908161921-create-entities.js
@@ -2,20 +2,20 @@
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
   async up(queryInterface, Sequelize) {
-    await queryInterface.createTable('entidades', {
-      id_entidad: {
+    await queryInterface.createTable('entities', {
+      id: {
         allowNull: false,
         autoIncrement: true,
         primaryKey: true,
         type: Sequelize.BIGINT
       },
-      nombre_entidad: {
+      name: {
         type: Sequelize.STRING,
         allowNull: false
       }
     });
   },
   async down(queryInterface) {
-    await queryInterface.dropTable('entidades');
+    await queryInterface.dropTable('entities');
   }
 };

--- a/migrations/20250908161928-create-complaints.js
+++ b/migrations/20250908161928-create-complaints.js
@@ -2,23 +2,23 @@
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
   async up(queryInterface, Sequelize) {
-    await queryInterface.createTable('quejas', {
-      id_queja: {
+    await queryInterface.createTable('complaints', {
+      id: {
         allowNull: false,
         autoIncrement: true,
         primaryKey: true,
         type: Sequelize.BIGINT
       },
-      descripcion_queja: {
+      description: {
         type: Sequelize.TEXT,
         allowNull: false
       },
-      isDeleted_queja: {
+      is_deleted: {
         type: Sequelize.BOOLEAN,
         allowNull: false,
         defaultValue: false
       },
-      id_entidad: {
+      entity_id: {
         type: Sequelize.BIGINT,
         references: {
           model: 'entities',
@@ -30,6 +30,6 @@ module.exports = {
     });
   },
   async down(queryInterface) {
-    await queryInterface.dropTable('quejas');
+    await queryInterface.dropTable('complaints');
   }
 };

--- a/migrations/20250908161928-create-quejas.js
+++ b/migrations/20250908161928-create-quejas.js
@@ -21,8 +21,8 @@ module.exports = {
       id_entidad: {
         type: Sequelize.BIGINT,
         references: {
-          model: 'entidades',
-          key: 'id_entidad'
+          model: 'entities',
+          key: 'id'
         },
         onUpdate: 'CASCADE',
         onDelete: 'SET NULL'

--- a/models/Complaint.js
+++ b/models/Complaint.js
@@ -3,25 +3,30 @@ const sequelize = require('../config/database');
 
 const Complaint = sequelize.define('Complaint', {
 
-  id_queja: {
+  id: {
     type: DataTypes.BIGINT,
     primaryKey: true,
     autoIncrement: true
   },
 
-  descripcion_queja: {
+
+  description: {
     type: DataTypes.TEXT,
     allowNull: false
   },
 
-  isDeleted_queja: {
+
+  is_deleted: {
+
     type: DataTypes.BOOLEAN,
     allowNull:false,
     defaultValue:false
   }
 
 }, {
-  tableName: 'quejas',
+
+  tableName: 'complaints',
+
   timestamps: false
 });
 

--- a/models/Complaint.js
+++ b/models/Complaint.js
@@ -1,7 +1,7 @@
 const { DataTypes } = require('sequelize');
 const sequelize = require('../config/database');
 
-const Queja = sequelize.define('Queja', {
+const Complaint = sequelize.define('Complaint', {
 
   id_queja: {
     type: DataTypes.BIGINT,
@@ -25,4 +25,4 @@ const Queja = sequelize.define('Queja', {
   timestamps: false
 });
 
-module.exports = Queja;
+module.exports = Complaint;

--- a/models/Entity.js
+++ b/models/Entity.js
@@ -1,22 +1,22 @@
 const { DataTypes } = require('sequelize');
 const sequelize = require('../config/database'); 
 
-const Entidad = sequelize.define('Entidad', {
+const Entity = sequelize.define('Entity', {
 
-  id_entidad: {
+  id: {
     type: DataTypes.BIGINT, 
     primaryKey: true,
     autoIncrement: true
   },
  
-  nombre_entidad: {
+  name: {
     type: DataTypes.STRING, 
     allowNull: false 
   }
 }, {
 
-  tableName: 'entidades', 
+  tableName: 'entities', 
   timestamps: false 
 });
 
-module.exports = Entidad;
+module.exports = Entity;

--- a/models/index.js
+++ b/models/index.js
@@ -1,12 +1,12 @@
 const sequelize = require('../config/database');
 const Entity= require('./Entity');
-const Queja = require('./Queja');
+const Complaint = require('./Complaint');
 
-Entity.hasMany(Queja, {
+Entity.hasMany(Complaint, {
   foreignKey: 'id_entidad' 
 });
 
-Queja.belongsTo(Entity, {
+Complaint.belongsTo(Entity, {
   foreignKey: 'id_entidad'
 });
 
@@ -14,5 +14,5 @@ Queja.belongsTo(Entity, {
 module.exports = {
   sequelize,
   Entity,
-  Queja
+  Complaint
 };

--- a/models/index.js
+++ b/models/index.js
@@ -3,11 +3,13 @@ const Entity= require('./Entity');
 const Complaint = require('./Complaint');
 
 Entity.hasMany(Complaint, {
-  foreignKey: 'id_entidad' 
+
+  foreignKey: 'entity_id' 
 });
 
 Complaint.belongsTo(Entity, {
-  foreignKey: 'id_entidad'
+  foreignKey: 'entity_id'
+
 });
 
 

--- a/models/index.js
+++ b/models/index.js
@@ -1,18 +1,18 @@
 const sequelize = require('../config/database');
-const Entidad = require('./Entidad');
+const Entity= require('./Entity');
 const Queja = require('./Queja');
 
-Entidad.hasMany(Queja, {
+Entity.hasMany(Queja, {
   foreignKey: 'id_entidad' 
 });
 
-Queja.belongsTo(Entidad, {
+Queja.belongsTo(Entity, {
   foreignKey: 'id_entidad'
 });
 
 
 module.exports = {
   sequelize,
-  Entidad,
+  Entity,
   Queja
 };

--- a/routes/quejas.js
+++ b/routes/quejas.js
@@ -19,15 +19,15 @@ router.get('/registrar', async (req, res) => {
 // POST /api/quejas → crea una nueva queja
 router.post('/', async (req, res) => {
   try {
-    const { texto, id_entidad } = req.body;
+    const { texto, entity_id } = req.body;
 
     if (!texto || texto.trim().length < 10 || texto.trim().length > 2000) {
       return res.status(400).json({ error: "La queja debe tener entre 10 y 2000 caracteres." });
     }
-    if (!id_entidad || isNaN(id_entidad)) {
+    if (!entity_id || isNaN(entity_id)) {
       return res.status(400).json({ error: "Debe seleccionar una entidad válida." });
     }
-    const queja = await createQueja({ texto, id_entidad });
+    const queja = await createQueja({ texto, entity_id });
     res.status(201).json({ message: "Queja registrada", data: queja });
   } catch {
     res.status(500).json({ error: 'Error al registrar la queja.' });

--- a/routes/quejas.js
+++ b/routes/quejas.js
@@ -27,7 +27,6 @@ router.post('/', async (req, res) => {
     if (!id_entidad || isNaN(id_entidad)) {
       return res.status(400).json({ error: "Debe seleccionar una entidad válida." });
     }
-
     const queja = await createQueja({ texto, id_entidad });
     res.status(201).json({ message: "Queja registrada", data: queja });
   } catch {

--- a/seeders/20250908160117-demo-entidades.js
+++ b/seeders/20250908160117-demo-entidades.js
@@ -3,15 +3,15 @@
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
   async up(queryInterface) {
-    await queryInterface.bulkInsert('entidades', [
-      { nombre_entidad: 'Acueducto y Alcantarillado de Tunja' },
-      { nombre_entidad: 'Veolia - Aseo' },
-      { nombre_entidad: 'Empresa de Energía de Boyacá' },
-      { nombre_entidad: 'Servicio de Gas Natural' }
+    await queryInterface.bulkInsert('entities', [
+      { name: 'Acueducto y Alcantarillado de Tunja' },
+      { name: 'Veolia - Aseo' },
+      { name: 'Empresa de Energía de Boyacá' },
+      { name: 'Servicio de Gas Natural' }
     ], {});
   },
 
   async down(queryInterface) {
-    await queryInterface.bulkDelete('entidades', null, {});
+    await queryInterface.bulkDelete('entities', null, {});
   }
 };

--- a/services/complaint.service.js
+++ b/services/complaint.service.js
@@ -1,0 +1,100 @@
+const { complaints, Entity } = require('../models');
+const { setCacheEntities } = require('../config/cache');
+
+// Obtener quejas paginadas por entidad
+exports.getPaginatedComplaintsForEntity = async (entityId, page = 1, limit = 10) => {
+  try {
+    const offset = (page - 1) * limit;
+
+    const { rows: complaints, count } = await complaints.findAndCountAll({
+      where: { Id_entity: entityId },
+      include: [{
+        model: Entity,
+        attributes: ['name_entity']
+      }],
+      order: [['id_queja', 'ASC']],
+      limit,
+      offset
+    });
+
+    return {
+      data: complaints,
+      page,
+      limit,
+      total: count,
+      totalPages: Math.ceil(count / limit)
+    };
+  } catch (error) {
+    console.error(error);
+    throw new Error('Error al obtener las quejas');
+  }
+};
+
+// Cargar entities en caché
+exports.loadEntities = async () => {
+  const entity = await Entity.findAll({
+    order: [['name_entity', 'ASC']]
+  });
+  setCacheEntities(entity);
+};
+
+// Obtener todas las entities
+exports.getEntities = async () => {
+  try {
+    const entities = await Entity.findAll({
+      order: [['Id_entity', 'ASC']]
+    });
+    return entities;
+  } catch (error) {
+    console.error(error);
+    throw new Error('Error al obtener las entities');
+  }
+};
+
+// Registrar una nueva queja
+exports.createComplaint = async ({ texto, Id_entity }) => {
+  if (!texto || texto.trim().length < 10 || texto.trim().length > 2000) {
+    throw new Error('La queja debe tener entre 10 y 2000 caracteres');
+  }
+
+  // Validar si la entidad existe
+  const entidad = await Entity.findByPk(Id_entity);
+  if (!entidad) {
+    throw new Error('La entidad especificada no existe');
+  }
+
+  // Insertar queja
+  const nuevaQueja = await complaints.create({
+    descripcion_queja: texto.trim(),
+    Id_entity
+  });
+
+  return nuevaQueja;
+};
+
+// Reporte: número de quejas por entidad
+exports.getComplaintsReportByEntity = async () => {
+  try {
+    const res = await Entity.findAll({
+      attributes: [
+        'Id_entity',
+        'name_entity',
+        [complaints.sequelize.fn('COUNT', complaints.sequelize.col('Quejas.id_queja')), 'total_quejas']
+      ],
+      include: [{
+        model: complaints,
+        attributes: []
+      }],
+      group: ['Entidad.Id_entity'],
+      order: [[complaints.sequelize.literal('total_quejas'), 'DESC']]
+    });
+    return res;
+  } catch (err) {
+    console.error('Error generando reporte de quejas por entidad:', err);
+    throw err;
+  }
+};
+
+
+
+

--- a/services/quejas.service.js
+++ b/services/quejas.service.js
@@ -1,4 +1,4 @@
-const { Queja, Entidad } = require('../models');
+const { Queja, Entity } = require('../models');
 const { setEntidadesCache } = require('../config/cache');
 
 // Obtener quejas paginadas por entidad
@@ -9,8 +9,8 @@ exports.getQuejasPaginadasForEntity = async (entidadId, page = 1, limit = 10) =>
     const { rows: quejas, count } = await Queja.findAndCountAll({
       where: { id_entidad: entidadId },
       include: [{
-        model: Entidad,
-        attributes: ['nombre_entidad']
+        model: Entity,
+        attributes: ['name']
       }],
       order: [['id_queja', 'ASC']],
       limit,
@@ -32,8 +32,8 @@ exports.getQuejasPaginadasForEntity = async (entidadId, page = 1, limit = 10) =>
 
 // Cargar entidades en caché
 exports.loadEntidades = async () => {
-  const entidades = await Entidad.findAll({
-    order: [['nombre_entidad', 'ASC']]
+  const entidades = await Entity.findAll({
+    order: [['name', 'ASC']]
   });
   setEntidadesCache(entidades);
 };
@@ -41,8 +41,8 @@ exports.loadEntidades = async () => {
 // Obtener todas las entidades
 exports.getEntidades = async () => {
   try {
-    const entidades = await Entidad.findAll({
-      order: [['id_entidad', 'ASC']]
+    const entidades = await Entity.findAll({
+      order: [['id', 'ASC']]
     });
     return entidades;
   } catch (error) {
@@ -58,12 +58,13 @@ exports.createQueja = async ({ texto, id_entidad }) => {
   }
 
   // Validar si la entidad existe
-  const entidad = await Entidad.findByPk(id_entidad);
+  const entidad = await Entity.findByPk(id_entidad);
+
   if (!entidad) {
     throw new Error('La entidad especificada no existe');
   }
 
-  // Insertar queja
+
   const nuevaQueja = await Queja.create({
     descripcion_queja: texto.trim(),
     id_entidad
@@ -75,17 +76,17 @@ exports.createQueja = async ({ texto, id_entidad }) => {
 // Reporte: número de quejas por entidad
 exports.getReporteQuejasPorEntidad = async () => {
   try {
-    const res = await Entidad.findAll({
+    const res = await Entity.findAll({
       attributes: [
-        'id_entidad',
-        'nombre_entidad',
+        'id',
+        'name',
         [Queja.sequelize.fn('COUNT', Queja.sequelize.col('Quejas.id_queja')), 'total_quejas']
       ],
       include: [{
         model: Queja,
         attributes: []
       }],
-      group: ['Entidad.id_entidad'],
+      group: ['Entity.id'],
       order: [[Queja.sequelize.literal('total_quejas'), 'DESC']]
     });
     return res;

--- a/services/quejas.service.js
+++ b/services/quejas.service.js
@@ -7,12 +7,14 @@ exports.getQuejasPaginadasForEntity = async (entidadId, page = 1, limit = 10) =>
     const offset = (page - 1) * limit;
 
     const { rows: quejas, count } = await Complaint.findAndCountAll({
-      where: { id_entidad: entidadId },
+
+      where: { entity_id: entidadId },
+
       include: [{
         model: Entity,
         attributes: ['name']
       }],
-      order: [['id_queja', 'ASC']],
+      order: [['id', 'ASC']],
       limit,
       offset
     });
@@ -52,22 +54,25 @@ exports.getEntidades = async () => {
 };
 
 // Registrar una nueva queja
-exports.createQueja = async ({ texto, id_entidad }) => {
+exports.createQueja = async ({ texto, entity_id }) => {
+
   if (!texto || texto.trim().length < 10 || texto.trim().length > 2000) {
     throw new Error('La queja debe tener entre 10 y 2000 caracteres');
   }
 
   // Validar si la entidad existe
-  const entidad = await Entity.findByPk(id_entidad);
+  const entidad = await Entity.findByPk(entity_id);
 
   if (!entidad) {
     throw new Error('La entidad especificada no existe');
   }
 
 
+
   const nuevaQueja = await Complaint.create({
-    descripcion_queja: texto.trim(),
-    id_entidad
+    description: texto.trim(),
+    entity_id
+
   });
 
   return nuevaQueja;
@@ -80,7 +85,9 @@ exports.getReporteQuejasPorEntidad = async () => {
       attributes: [
         'id',
         'name',
-        [Complaint.sequelize.fn('COUNT', Complaint.sequelize.col('Complaints.id_queja')), 'total_quejas']
+
+        [Complaint.sequelize.fn('COUNT', Complaint.sequelize.col('Complaints.id')), 'total_quejas']
+
       ],
       include: [{
         model: Complaint,

--- a/services/quejas.service.js
+++ b/services/quejas.service.js
@@ -1,4 +1,4 @@
-const { Queja, Entity } = require('../models');
+const { Complaint, Entity } = require('../models');
 const { setEntidadesCache } = require('../config/cache');
 
 // Obtener quejas paginadas por entidad
@@ -6,7 +6,7 @@ exports.getQuejasPaginadasForEntity = async (entidadId, page = 1, limit = 10) =>
   try {
     const offset = (page - 1) * limit;
 
-    const { rows: quejas, count } = await Queja.findAndCountAll({
+    const { rows: quejas, count } = await Complaint.findAndCountAll({
       where: { id_entidad: entidadId },
       include: [{
         model: Entity,
@@ -65,7 +65,7 @@ exports.createQueja = async ({ texto, id_entidad }) => {
   }
 
 
-  const nuevaQueja = await Queja.create({
+  const nuevaQueja = await Complaint.create({
     descripcion_queja: texto.trim(),
     id_entidad
   });
@@ -80,14 +80,14 @@ exports.getReporteQuejasPorEntidad = async () => {
       attributes: [
         'id',
         'name',
-        [Queja.sequelize.fn('COUNT', Queja.sequelize.col('Quejas.id_queja')), 'total_quejas']
+        [Complaint.sequelize.fn('COUNT', Complaint.sequelize.col('Complaints.id_queja')), 'total_quejas']
       ],
       include: [{
-        model: Queja,
+        model: Complaint,
         attributes: []
       }],
       group: ['Entity.id'],
-      order: [[Queja.sequelize.literal('total_quejas'), 'DESC']]
+      order: [[Complaint.sequelize.literal('total_quejas'), 'DESC']]
     });
     return res;
   } catch (err) {

--- a/services/quejas.service.js
+++ b/services/quejas.service.js
@@ -8,7 +8,10 @@ exports.getQuejasPaginadasForEntity = async (entidadId, page = 1, limit = 10) =>
 
     const { rows: quejas, count } = await Complaint.findAndCountAll({
 
-      where: { entity_id: entidadId },
+      where: { 
+        entity_id: entidadId,
+        is_deleted: false
+       },
 
       include: [{
         model: Entity,

--- a/test-jest/quejas.test.js
+++ b/test-jest/quejas.test.js
@@ -41,15 +41,15 @@ describe('Rutas de quejas', () => {
 
   describe('POST /', () => {
     it('debería crear una queja válida', async () => {
-      createQueja.mockResolvedValue({ id_queja: 1, descripcion_queja: 'Texto de prueba', id_entidad: 1 });
+      createQueja.mockResolvedValue({ id: 1, description: 'Texto de prueba', entity_id: 1 });
 
       const res = await request(app)
         .post('/')
-        .send({ texto: 'Texto de prueba', id_entidad: 1 });
+        .send({ texto: 'Texto de prueba', entity_id: 1 });
 
       expect(res.status).toBe(201);
       expect(res.body).toHaveProperty('message', 'Queja registrada');
-      expect(res.body.data).toEqual({ id_queja: 1, descripcion_queja: 'Texto de prueba', id_entidad: 1 });
+      expect(res.body.data).toEqual({ id: 1, description: 'Texto de prueba', entity_id: 1 });
     });
 
     it('debería rechazar texto corto', async () => {

--- a/views/lista-quejas.pug
+++ b/views/lista-quejas.pug
@@ -8,7 +8,7 @@ block content
         select.form-select#entidad(name="entidad")
           option(value="") Seleccione una entidad...
           each entidad in entidades
-            option(value=entidad.id_entidad) #{entidad.nombre_entidad}
+            option(value=entidad.id) #{entidad.name}
 
       // Tabla de quejas
       table.table.table-bordered

--- a/views/lista-quejas.pug
+++ b/views/lista-quejas.pug
@@ -56,7 +56,7 @@ block content
         if (result.data && result.data.length) {
           result.data.forEach(q => {
             const tr = document.createElement('tr');
-            tr.innerHTML = `<td>${q.descripcion_queja}</td>`;
+            tr.innerHTML = `<td>${q.description}</td>`;
             tbody.appendChild(tr);
           });
         } else {

--- a/views/registrar.pug
+++ b/views/registrar.pug
@@ -36,13 +36,13 @@ block content
         return;
       }
 
-      const id_entidad = Number(id_entidad_val);
+      const entity_id = Number(id_entidad_val);
 
       try {
         const res = await fetch('/api/quejas', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ id_entidad, texto })
+          body: JSON.stringify({ entity_id, texto })
         });
         const data = await res.json();
 

--- a/views/registrar.pug
+++ b/views/registrar.pug
@@ -9,7 +9,7 @@ block content
       select(name='id_entidad', id='id_entidad', required, style='width:100%;padding:8px;')
         option(value='') Seleccione una entidad...
         each entidad in entidades
-          option(value=entidad.id_entidad)= entidad.nombre_entidad
+          option(value=entidad.id)= entidad.name
 
     div(style='margin-bottom:20px;')
       label(for='texto', style='display:block;margin-bottom:5px;') Queja

--- a/views/reportes.pug
+++ b/views/reportes.pug
@@ -40,7 +40,7 @@ block content
 
         tbody.innerHTML = '';
         data.forEach(row => {
-          const nombre = escapeHtml(row.nombre_entidad || 'Sin nombre');
+          const nombre = escapeHtml(row.name || 'Sin nombre');
           const total = Number(row.total_quejas || 0);
 
           const tr = document.createElement('tr');


### PR DESCRIPTION
## 📝 Descripción

Se agrega un filtro en el servicio de obtención de quejas para que no traiga quejas con estado eliminado

## 📌 Issue Relacionado

- Cierra #48

## tipo de Cambio

- [ ] 🐛 Corrección de bug (Bug fix)
- [x] ✨ Nueva funcionalidad (New feature)
- [ ] 🎨 Mejora de UI/UX (UI/UX improvement)
- [ ] ⚡️ Mejora de rendimiento (Performance improvement)
- [ ] ♻️ Refactorización (Code refactor)
- [ ] 📚 Documentación (Documentation)
- [ ] 🔧 Tarea de configuración/build (Chore)
- [ ] ✅ Pruebas (Tests)

## ✅ ¿Cómo se ha probado?

**Pruebas manuales:**
1. Inicié el servidor con `npm start`.
2. Verifiqué que el nuevo componente se renderiza correctamente.

**Pruebas automáticas:**
- Ejecuté `npm test` y todos los tests pasaron exitosamente.

