### PR TITLE
Se crea un nuevo endpoint PUT /api/complaints/change-state/:id

### DIFF
--- a/services/quejas.service.js
+++ b/services/quejas.service.js
@@ -103,6 +103,7 @@ exports.getReporteQuejasPorEntidad = async () => {
   }
 };
 
+
 exports.deleteComplaint = async (complaintId) => {
   try {
     const complaint = await Complaint.findByPk(complaintId);
@@ -114,5 +115,22 @@ exports.deleteComplaint = async (complaintId) => {
   } catch (error) {
     console.error('Error al eliminar la queja:', error);
     throw new Error('Error al eliminar la queja');
+  }
+};
+
+
+exports.changeComplaintState = async (complaintId, newState) => {
+  try {
+    const complaint = await Complaint.findByPk(complaintId);
+    if (complaint) {
+      complaint.state = newState;
+      await complaint.save();
+      return true;
+    } else {
+      return false;
+    }
+  } catch (error) {
+    console.error('Error al cambiar el estado de la queja:', error);
+    throw new Error('Error al cambiar el estado de la queja');
   }
 };


### PR DESCRIPTION

## 📝 Descripción

Se crea un nuevo endpoint PUT /api/complaints/change-state/:id par cambiar el estado de una queja existente. El endpoint recibe el ID de la queja como parámetro de ruta y el nuevo estado en el cuerpo de la solicitud. Se valida la entrada y se actualiza el estado de la queja en la base de datos si las credenciales son válidas.

## 📌 Issue Relacionado

- Cierra #96 

## tipo de Cambio

- [ ] 🐛 Corrección de bug (Bug fix)
- [x] ✨ Nueva funcionalidad (New feature)
- [ ] 🎨 Mejora de UI/UX (UI/UX improvement)
- [ ] ⚡️ Mejora de rendimiento (Performance improvement)
- [ ] ♻️ Refactorización (Code refactor)
- [ ] 📚 Documentación (Documentation)
- [ ] 🔧 Tarea de configuración/build (Chore)
- [ ] ✅ Pruebas (Tests)

## ✅ ¿Cómo se ha probado?


**Pruebas automáticas:**
- Ejecuté `npm test` y todos los tests pasaron exitosamente.

