### PR TITLE
Se crea un nuevo endpoint para obtener los posibles estados de una queja

### DIFF
--- a/routes/quejas.js
+++ b/routes/quejas.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = express.Router();
 
 const { getEntitiesCache } = require('../config/cache');
-const { createQueja, getQuejasPaginadasForEntity, getReporteQuejasPorEntidad, deleteComplaint, changeComplaintState, getComplaintById} = require('../services/quejas.service');
+const { createQueja, getQuejasPaginadasForEntity, getReporteQuejasPorEntidad, deleteComplaint, changeComplaintState, getComplaintById, getComplaintStates} = require('../services/quejas.service');
 const { enviarCorreo } = require('../services/email.service'); //importamos el servicio de correo email.srviece.js
 const { verifyRecaptcha } = require('../middleware/recaptcha');
 
@@ -178,6 +178,15 @@ router.get('/:id', async (req, res) => {
   }
 });
 
-
+// GET /api/complaints/states
+router.get('/data/states', async (req, res) => {
+  try {
+    const states = await getComplaintStates();
+    res.json(states);
+  } catch (err) {
+    console.error('Error en /api/complaints/states:', err.message || err);
+    res.status(500).json({ error: 'Error al obtener los estados de las quejas.', details: err.message });
+  }
+});
 
 module.exports = router;

--- a/services/quejas.service.js
+++ b/services/quejas.service.js
@@ -1,5 +1,6 @@
 const { Complaint, Entity } = require('../models');
 const { setEntitiesCache } = require('../config/cache');
+const  COMPLAINT_STATES  = require('../config/constants');
 
 // Obtener quejas paginadas por entidad
 exports.getQuejasPaginadasForEntity = async (entidadId, page = 1, limit = 10) => {
@@ -148,5 +149,14 @@ exports.getComplaintById = async (complaintId) => {
   } catch (error) {
     console.error('Error al obtener la queja por ID:', error);
     throw new Error('Error al obtener la queja por ID');
+  }
+};
+
+exports.getComplaintStates = async () => {
+  try {
+    return Object.values(COMPLAINT_STATES);
+  } catch (error) {
+    console.error('Error al obtener los estados de las quejas:', error);
+    throw new Error('Error al obtener los estados de las quejas');
   }
 };


### PR DESCRIPTION
## 📝 Descripción
Se crea un nuevo endpoint para obtener los posibles estados de una queja para ser usado en el modal del frontend

## 📌 Issue Relacionado

- Cierra #105 

## tipo de Cambio

- [ ] 🐛 Corrección de bug (Bug fix)
- [x] ✨ Nueva funcionalidad (New feature)
- [ ] 🎨 Mejora de UI/UX (UI/UX improvement)
- [ ] ⚡️ Mejora de rendimiento (Performance improvement)
- [ ] ♻️ Refactorización (Code refactor)
- [ ] 📚 Documentación (Documentation)
- [ ] 🔧 Tarea de configuración/build (Chore)
- [ ] ✅ Pruebas (Tests)

## ✅ ¿Cómo se ha probado?

**Pruebas manuales:**
1. Inicié el servidor con `npm start`.
2. Navegué a la ruta `/api/quejas/data/states`.
3. Verifiqué que el nuevo componente se renderiza correctamente.

**Pruebas automáticas:**
- Ejecuté `npm test` y todos los tests pasaron exitosamente.
