### PR TITLE
se corrige el error al obtener el  reporte

### DIFF
--- a/routes/quejas.js
+++ b/routes/quejas.js
@@ -5,7 +5,7 @@ const { getEntitiesCache } = require('../config/cache');
 const {
   createQueja,
   getQuejasPaginadasForEntity,
-  getComplaintsReportByEntity,
+  getComplaintReportByEntity,
   deleteComplaint,
   changeComplaintState,
   getComplaintById,
@@ -143,7 +143,7 @@ async function checkAdminPass(req) {
 // GET /api/complaints/quejas-por-entidad → reporte
 router.get('/quejas-por-entidad', async (req, res) => {
   try {
-    const rows = await getComplaintsReportByEntity();
+    const rows = await getComplaintReportByEntity();
     res.json(rows);
   } catch (err) {
     console.error(


### PR DESCRIPTION
## 📝 Descripción

Dentro de quejas.js se cambia getComplaintsReportByEntity a getComplaintReportByEntity, lo cual estaba generando un error al cargar el número de quejas por entidad.

## 📌 Issue Relacionado

- Cierra # (número del issue)

## tipo de Cambio

- [X ] 🐛 Corrección de bug (Bug fix)
- [ ] ✨ Nueva funcionalidad (New feature)
- [ ] 🎨 Mejora de UI/UX (UI/UX improvement)
- [ ] ⚡️ Mejora de rendimiento (Performance improvement)
- [ ] ♻️ Refactorización (Code refactor)
- [ ] 📚 Documentación (Documentation)
- [ ] 🔧 Tarea de configuración/build (Chore)
- [ ] ✅ Pruebas (Tests)

## ✅ ¿Cómo se ha probado?

**Pruebas manuales:**

1. Inicié el servidor con `npm start`.
2. Navegué a la ruta `/ejemplo`.
3. Verifiqué que el nuevo componente se renderiza correctamente.

**Pruebas automáticas:**

- Ejecuté `npm test` y todos los tests pasaron exitosamente.

## Notas Adicionales para el Revisor

...
