### PR TITLE
Añade middleware para validar solicitudes utilizando express-validator

### DIFF
--- a/middleware/validateRequest.js
+++ b/middleware/validateRequest.js
@@ -1,0 +1,14 @@
+import { validationResult } from 'express-validator';
+
+export const validateRequest = (req, res, next) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({
+      errors: errors.array().map((err) => ({
+        field: err.path,
+        message: err.msg,
+      })),
+    });
+  }
+  next();
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "debug": "~2.6.9",
         "dotenv": "^17.2.1",
         "express": "^4.21.2",
+        "express-validator": "^7.2.1",
         "http-errors": "~1.6.3",
         "morgan": "^1.10.1",
         "nodemailer": "^7.0.6",
@@ -5592,6 +5593,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-validator": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.2.1.tgz",
+      "integrity": "sha512-CjNE6aakfpuwGaHQZ3m8ltCG2Qvivd7RHtVMS/6nVxOM7xVGqr4bhflsm4+N5FP5zI7Zxp+Hae+9RE+o8e3ZOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "validator": "~13.12.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/express-validator/node_modules/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/express/node_modules/cookie": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "debug": "~2.6.9",
     "dotenv": "^17.2.1",
     "express": "^4.21.2",
+    "express-validator": "^7.2.1",
     "http-errors": "~1.6.3",
     "morgan": "^1.10.1",
     "nodemailer": "^7.0.6",

--- a/test-jest/unit/middleware/validationRequest.test.js
+++ b/test-jest/unit/middleware/validationRequest.test.js
@@ -1,0 +1,70 @@
+const { validationResult } = require('express-validator');
+const { validateRequest } = require('../../../middleware/validateRequest.js');
+
+jest.mock('express-validator', () => ({
+  validationResult: jest.fn(),
+}));
+
+const mockValidationResult = validationResult;
+
+describe('Middleware: validateRequest', () => {
+  let mockRequest;
+  let mockResponse;
+  let nextFunction;
+
+  beforeEach(() => {
+    mockRequest = {};
+    mockResponse = {
+      status: jest.fn(() => mockResponse),
+      json: jest.fn(() => mockResponse),
+    };
+    nextFunction = jest.fn();
+    jest.clearAllMocks();
+  });
+
+  it('should return 400 and formatted errors if validation fails', () => {
+    const mockErrors = [
+      { type: 'field', msg: 'Invalid email', path: 'email', location: 'body' },
+      {
+        type: 'field',
+        msg: 'Password is required',
+        path: 'password',
+        location: 'body',
+      },
+    ];
+
+    mockValidationResult.mockReturnValue({
+      isEmpty: () => false,
+      array: () => mockErrors,
+    });
+
+    validateRequest(mockRequest, mockResponse, nextFunction);
+
+    expect(nextFunction).not.toHaveBeenCalled();
+
+    expect(mockResponse.status).toHaveBeenCalledTimes(1);
+    expect(mockResponse.status).toHaveBeenCalledWith(400);
+
+    const expectedErrorResponse = {
+      errors: [
+        { field: 'email', message: 'Invalid email' },
+        { field: 'password', message: 'Password is required' },
+      ],
+    };
+    expect(mockResponse.json).toHaveBeenCalledTimes(1);
+    expect(mockResponse.json).toHaveBeenCalledWith(expectedErrorResponse);
+  });
+
+  it('should call next() if validation passes', () => {
+    mockValidationResult.mockReturnValue({
+      isEmpty: () => true,
+      array: () => [],
+    });
+
+    validateRequest(mockRequest, mockResponse, nextFunction);
+    expect(nextFunction).toHaveBeenCalledTimes(1);
+    expect(nextFunction).toHaveBeenCalledWith();
+    expect(mockResponse.status).not.toHaveBeenCalled();
+    expect(mockResponse.json).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 📝 Descripción

Añade middleware para validar solicitudes utilizando express-validator y se añaden las pruebas unitarias correspondientes

## tipo de Cambio

- [ ] 🐛 Corrección de bug (Bug fix)
- [ ] ✨ Nueva funcionalidad (New feature)
- [ ] 🎨 Mejora de UI/UX (UI/UX improvement)
- [ ] ⚡️ Mejora de rendimiento (Performance improvement)
- [x] ♻️ Refactorización (Code refactor)
- [ ] 📚 Documentación (Documentation)
- [ ] 🔧 Tarea de configuración/build (Chore)
- [ ] ✅ Pruebas (Tests)

## ✅ ¿Cómo se ha probado?

**Pruebas manuales:**

1. Inicié el servidor con `npm start`.

**Pruebas automáticas:**

- Ejecuté `npm test` y todos los tests pasaron exitosamente.