### PR TITLE
Se Renombra función getQuejasPaginadasForEntity a getComplaintListByEntity para mejorar la claridad y consistencia.

### DIFF
--- a/routes/quejas.js
+++ b/routes/quejas.js
@@ -3,7 +3,7 @@ const router = express.Router();
 
 const { getEntitiesCache } = require('../config/cache');
 const {
-  getQuejasPaginadasForEntity,
+  getComplaintListByEntity,
   getComplaintReportByEntity,
   deleteComplaint,
   changeComplaintState,
@@ -67,7 +67,7 @@ async function obtenerQuejas(req, res) {
 
     sendNotificationEmail(entidadId, req);
 
-    const result = await getQuejasPaginadasForEntity(entidadId, page, limit);
+    const result = await getComplaintListByEntity(entidadId, page, limit);
     res.json(result);
   } catch {
     res.status(500).json({ error: 'Error al obtener las quejas.' });

--- a/services/quejas.service.js
+++ b/services/quejas.service.js
@@ -3,7 +3,7 @@ const { setEntitiesCache } = require('../config/cache');
 const COMPLAINT_STATES = require('../config/constants');
 const complaintRepository = require('../repositories/complaintRepository');
 
-exports.getQuejasPaginadasForEntity = async (entidadId, page, limit) => {
+exports.getComplaintListByEntity = async (entidadId, page, limit) => {
   try {
     const paginatedResult =
       await complaintRepository.getPaginatedComplaintsForEntity(


### PR DESCRIPTION
## 📝 Descripción

Se Renombra función getQuejasPaginadasForEntity a getComplaintListByEntity para mejorar la claridad y consistencia.

## tipo de Cambio

- [ ] 🐛 Corrección de bug (Bug fix)
- [ ] ✨ Nueva funcionalidad (New feature)
- [ ] 🎨 Mejora de UI/UX (UI/UX improvement)
- [ ] ⚡️ Mejora de rendimiento (Performance improvement)
- [x] ♻️ Refactorización (Code refactor)
- [ ] 📚 Documentación (Documentation)
- [ ] 🔧 Tarea de configuración/build (Chore)
- [ ] ✅ Pruebas (Tests)

## ✅ ¿Cómo se ha probado?

**Pruebas manuales:**

1. Inicié el servidor con `npm start`.

**Pruebas automáticas:**

- Ejecuté `npm test` y todos los tests pasaron exitosamente.
