### PR TITLE
Se arregla error que impide abrir despegable de información de sesion en las vista de ver quejas

### DIFF
--- a/views/comment.pug
+++ b/views/comment.pug
@@ -59,8 +59,6 @@ block content
             button.btn.btn-primary(type="button" onclick="logoutAndRedirect()") Iniciar sesión
 
 
-    // Scripts
-    script(src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js")
     script(src="/js/mainComment.js")
 
 


### PR DESCRIPTION
## 📝 Descripción

Se arregla error que impide abrir despegable de información de sesion en las vista de ver quejas

## tipo de Cambio

- [x] 🐛 Corrección de bug (Bug fix)
- [ ] ✨ Nueva funcionalidad (New feature)
- [ ] 🎨 Mejora de UI/UX (UI/UX improvement)
- [ ] ⚡️ Mejora de rendimiento (Performance improvement)
- [ ] ♻️ Refactorización (Code refactor)
- [ ] 📚 Documentación (Documentation)
- [ ] 🔧 Tarea de configuración/build (Chore)
- [ ] ✅ Pruebas (Tests)

## ✅ ¿Cómo se ha probado?

**Pruebas manuales:**

1. Inicié el servidor con `npm start`.
3. Verifiqué que el nuevo componente se renderiza correctamente.

**Pruebas automáticas:**

- Ejecuté `npm test` y todos los tests pasaron exitosamente.

